### PR TITLE
Update Restrict feature

### DIFF
--- a/sbill
+++ b/sbill
@@ -21,7 +21,7 @@ isRestricted = True                          # True = display only jobs related 
 AdminAccounts = ['admin']                   # Admin account to grant special permission even when isRestricted = True
 SLURM_STARTDATE = '2024-08-16T00:00:00'
 
-Service = 'SHr'
+Service = 'Service'
 calService = lambda billing, elapsedraw : billing*elapsedraw/60/60/100
 ServiceDecimal = 3
 


### PR DESCRIPTION
1. Fix a major bug in isRestrict option, that cannot completely restrict users from seeing jobs in other accounts. This feature is rewritten to make the condition stricter.
2. Add AdminAccount to be used when isRestrict = False, to grant special permission to some users, having the specific Slurm account, to be able to see all jobs.