### PR TITLE
Update sbill 1.5.0

### DIFF
--- a/Installation
+++ b/Installation
@@ -6,9 +6,12 @@ Installation:
 --------------
 __HPC__ = 'XXX HPC of XXX center'             # Name of your system
 
-key = ['billing','cpu','gres/gpu:a100','mem']  # Keywords to be captured from alloctres field of sacct => [billing, ncpus, ngpus, allocmem] fields
+# 1) Treskey[0] = Slurm billing
+# 2) Treskey[1] = Num GPU
+# 3) Treskey[2] = Ram memory
+Treskey = ['billing','gres/gpu:a100','mem']    # Keywords to be captured from AllocTres in sacct
 isRestricted = True                            # True = display only jobs related by associated accounts
-AdminAccounts = ['thaisc']                     # Admin account to grant special permission even when isRestricted = True
+AdminAccounts = ['admin']                      # Admin account to grant special permission even when isRestricted = True
 SLURM_STARTDATE = '2023-04-06T00:00:00'        # Reference start date shown in --help
 
 Service = 'Service'                                                        # Billing unit of your system                  
@@ -23,7 +26,8 @@ GPUusage = 'GPU-card-hour'                                                 # GPU
 calGPUusage = lambda ngpu, elapsedraw : ngpu*elapsedraw/60/60              # How to calculated the GPU usage
 GPUusageDecimal = 2                                                        # Number of decimal to be displayed.
 
-GLOBAL_SBILL_DEFAULT_FORMAT = ['JobID','JobName%10','Account','Partition','NCPUS','NGPUS','Elapsed','State',Service]  # Default sbill format of your system
+GLOBAL_SBILL_DEFAULT_FORMAT = ['JobID','JobName%10','Account','Partition','NCPUS','NGPUS','Elapsed','State',Service]
+GLOBAL_SBILL_LONG_FORMAT    = ['JobID','JobName%10','User','Account','Partition','NNodes','NCPUS','NGPUS','AllocRam','NodeList%24','Elapsed','State',Service]
 --------------
 
 *** Important note ***

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SBILL-SLURM
-Query SLURM billing per job via SLURM sacct command
+Query SLURM billing per job through SLURM sacct command
 
 SBILL version:
-1.4.7 (02 September 2024)
+1.5.0 (06 January 2025)
 
 Dependencies:
 + python (>=3.1.0)  -- subprocess, math, os, sys, str.format
@@ -10,7 +10,7 @@ Dependencies:
 + SLURM
 
 Note:
-1. When doing timely utilization reports, the --truncate option (from sacct) must be used for correctness.
+1. When doing timely net utilization reports, the -T, --trim, --trim-job or --truncate option (from sacct) must be used for correctness.
 2. AllocMem field does not follow the unit specified by --units. 
 
 | Example:|
@@ -112,7 +112,3 @@ OPTIONS:
   --> configured for XXX HPC of XXX center
 
 ```
-
-Known issue:
-- When using '--format=' option, if some letter cases are NOT EXACTLY as outputted by '--helpformat', then 'KeyError:' may be emitted in some circumstances, such as 'sbill -a --format=jobid,JobName'. In SBILL, 'JobID' acts as job reference tag, thus, may be the cause of this issue.  
-- When using '-state' instead of '--state', users will get 'No jobs to be displayed' instead of 'Unknown options/arguments'. This is because '--state' has a synonym '-s', but the current version does not include this in '--help'.

--- a/sbill
+++ b/sbill
@@ -1,8 +1,8 @@
 #!/usr/bin/python3
 #
-# SBILL version 1.4.7
+# SBILL version 1.5.0
 #
-# Query SLURM billing per job through SLURM sacct command
+# Query SLURM job billing and information through SLURM sacct command
 #
 # Copyright (c) 2024, Somrath Kanoksirirath.
 # All rights reserved under BSD 3-clause license.
@@ -12,12 +12,16 @@
 # + numpy  (>=1.11.0) -- Optional, only for --histogram option
 # + SLURM
 
-__version__ = '1.4.7 (02 September 2024)'
+__version__ = '1.5.0 (06-Jan-2025)'
 __HPC__ = 'XXX HPC of XXX center'
 
 # Set up
-Treskey = ['billing','cpu','gres/gpu:a100','mem']  # Keywords to be captured from AllocTres in sacct
-SLURM_STARTDATE = '2024-09-02T00:00:00'
+# Requirement: 
+# 1) Treskey[0] = Slurm billing
+# 2) Treskey[1] = Num GPU
+# 3) Treskey[2] = Ram memory
+Treskey = ['billing','gres/gpu:a100','mem']  # Keywords to be captured from AllocTres in sacct
+SLURM_STARTDATE = '2025-01-06T00:00:00'
 
 Service = 'Service'
 calService = lambda billing, elapsedraw : billing*elapsedraw/60/60/100
@@ -32,6 +36,7 @@ calGPUusage = lambda ngpu, elapsedraw : ngpu*elapsedraw/60/60
 GPUusageDecimal = 2
 
 GLOBAL_SBILL_DEFAULT_FORMAT = ['JobID','JobName%10','Account','Partition','NCPUS','NGPUS','Elapsed','State',Service]
+GLOBAL_SBILL_LONG_FORMAT    = ['JobID','JobName%10','User','Account','Partition','NNodes','NCPUS','NGPUS','AllocRam','NodeList%24','Elapsed','State',Service]
 
 isRestricted = True            # True = display only jobs related by associated accounts
 AdminAccounts = ['admin']      # Admin account to grant special permission even when isRestricted = True
@@ -46,7 +51,7 @@ AdminAccounts = ['admin']      # Admin account to grant special permission even 
 def show_sbill_usage():
     print("Usage: sbill [OPTIONS]")
     print("")
-    print("Query slurm billing per job")
+    print("Query job billing and information")
     print("")
     print("OPTIONS:")
     print("  -A, --accounts=<slurm_account_list>")
@@ -75,20 +80,27 @@ def show_sbill_usage():
     print("      print the fields that can be specified with the --format option")
     print("")
     print("  -H, --histogram=<number_of_bins>[:field]")
-    print("      compute histogram of the displayed jobs using the input number of bins")
-    print("      [Note: Optional field can only be "+Service+", "+CPUusage+", or "+GPUusage+"]")
+    print("      quickly compute histogram of the displayed jobs using the input number of bins")
+    print("      [Note: The supported fields are "+Service+", "+CPUusage+", "+GPUusage+",")
+    print("                                      NNode, NCPU, NGPU, RunSec, RunMin, RunHour]")
     print("")
     print("  -j, --jobs=<slurm_job>")
     print("      display only the specified job")
     print("")
+    print("  -l, --long")
+    print("      equivalent to \'--format="+','.join(GLOBAL_SBILL_LONG_FORMAT)+"\'")
+    print("")
     print("  --name=<slurm_jobname_list>")
     print("      display only jobs that have these names")
     print("")
-    print("  -i, --nnodes=<min[-max]>")
-    print("      display only jobs that ran with this specified number of nodes")
+    print("  -i, --nnodes=<num> or <min-max>")
+    print("      display only jobs that ran with the specified number of nodes")
     print("")
-    print("  -I, --ncpus=<min-[max]>")
-    print("      display only jobs that ran with this specified number of CPUs")
+    print("  --ncpus=<num> or <min-max>")
+    print("      display only jobs that ran with the specified number of CPUs")
+    print("")
+    print("  --ngpus=<num> or <min-max>")
+    print("      display only jobs that ran with the specified number of GPUs")
     print("")
     print("  --noconvert")
     print("      do not convert units, e.g., 2048M won't get converted to 2G")
@@ -99,7 +111,7 @@ def show_sbill_usage():
     print("  -r, --partition=<slurm_partition_list>")
     print("      display only jobs that ran on these partitions")
     print("")
-    print("  --range=min[-max]")
+    print("  --range=<min[-max]>")
     print("      specify min and max of "+Service+" to filter jobs")
     print("")    
     print("  --to_csv=<filename>")
@@ -112,11 +124,15 @@ def show_sbill_usage():
     print("  --state=<COMPLETED,FAILED,CANCELED,TIMEOUT,...>")
     print("      display only jobs marked with these state (no abbreviation)")
     print("")
-    print("  --sumby=[Account,User]")
-    print("      sum the "+Service+" of the displayed jobs by [Account or User]")
+    print("  --sum-by=[Account,User], --sumby=[Account,User]")
+    print("      sum "+Service+" of the displayed jobs by [Account or User]")
+    print("  --sum-by-account, --sumbyaccount, --sum-byaccount, --sumby-account")
+    print("      equivalent to --sumby=Account")
+    print("  --sum-by-user, --sumbyuser, --sum-byuser, --sumby-user")
+    print("      equivalent to --sumby=User")
     print("")
-    print("  -T, --truncate")
-    print("      Truncate start and end time of jobs, according to --starttime and --endtime")
+    print("  -T, --trim, --trim-jobtime, --truncate")
+    print("      Trim job runtime or truncate start and end time of jobs, according to --starttime and --endtime")
     print("      Note: When doing a timely utilization report, this option MUST be used for correctness.")
     print("")
     print("  -u, --user=<slurm_user_list>")
@@ -129,7 +145,7 @@ def show_sbill_usage():
     print("      print version and exit")
     print("")
     print("  -X, --summary")
-    print("      display only the summary report")
+    print("      display only the summary report (implicitly infer --trim-jobtime)")
     print("")
     print("  ---------")
     print("")
@@ -161,6 +177,8 @@ is_show_job_histogram = False
 nbin_histogram = 1
 field_histogram = Service  # Only for int field that also displayed ***
 range_minmax = []
+range_ncpu_minmax = []
+range_ngpu_minmax = []
 is_show_total_SU = True
 sum_by = []
 csv_outfile = ''
@@ -208,7 +226,8 @@ def parse_filter_opts(i, opt1, opt2, has_argv, var=slurm_filter_opts):
 
 while i < len(argv) :
     j = i
-    # Slurm filter options
+
+    # *** Slurm filter options ***
     try:
         i = parse_filter_opts(i,'-A','--accounts', has_argv=True)
     except IndexError :
@@ -239,7 +258,7 @@ while i < len(argv) :
     if i != j : continue ;
 
     try:
-        i = parse_filter_opts(i,'','--name', has_argv=True)
+        i = parse_filter_opts(i,'--name','--name', has_argv=True)
     except IndexError :
         print('Invalid input argument in --name option :: List of job names was NOT given.')
         exit(1)
@@ -252,12 +271,14 @@ while i < len(argv) :
         exit(1)
     if i != j : continue ;
 
-    try:
-        i = parse_filter_opts(i,'-I','--ncpus', has_argv=True)
-    except IndexError :
-        print('Invalid input argument in -I, --ncpus option :: The number of CPUs was NOT given.')
-        exit(1)
-    if i != j : continue ;
+    # *** There seem to be a bug in this SACCT option, when the job contains GPUs *** 
+    #     --> Implement this ourself
+    #try:
+    #    i = parse_filter_opts(i,'-I','--ncpus', has_argv=True)
+    #except IndexError :
+    #    print('Invalid input argument in -I, --ncpus option :: The number of CPUs was NOT given.')
+    #    exit(1)
+    #if i != j : continue ;
 
     try:
         i = parse_filter_opts(i,'-N','--nodelist', has_argv=True)
@@ -280,9 +301,6 @@ while i < len(argv) :
         exit(1)
     if i != j : continue ;
 
-    i = parse_filter_opts(i,'-T','--truncate', has_argv=False)
-    if i != j : continue ;
-
     try:
         i = parse_filter_opts(i,'-u','--user', has_argv=True)
     except IndexError :
@@ -290,24 +308,10 @@ while i < len(argv) :
         exit(1)
     if i != j : continue ;
 
-    # Sbill filter options
-    try:
-        i = parse_filter_opts(i,'-s','--state', has_argv=True, var=temp_opt) # Borrow
-    except IndexError :
-        print('Invalid input argument in -s, --state option :: List of states was NOT given.')
-        exit(1)
-    if len(temp_opt) > 1 :
-        state_selected = temp_opt[1].split(',')
-    elif len(temp_opt) == 1 :
-        if temp_opt[0].startswith('-s') :
-            state_selected = temp_opt[0][2:].split(',')
-        elif temp_opt[0].startswith('--state=') :
-            state_selected = temp_opt[0][8:].split(',')
-    if i != j : temp_opt = [] ; continue ;
 
-    # Format options
+    # *** Format option ***
     try:
-        i = parse_filter_opts(i,'-o','--format', has_argv=True, var=temp_opt) # Borrow
+        i = parse_filter_opts(i,'-o','--format', has_argv=True, var=temp_opt) 
     except IndexError :
         print('Invalid input argument in -o, --format option :: Format was not specified.')
         exit(1)
@@ -320,11 +324,160 @@ while i < len(argv) :
             slurm_format_opts = temp_opt[0][9:].split(',')
     if i != j : temp_opt = [] ; continue ;
 
-    # Output options
+    if argv[i] == '-l' or argv[i] == '--long' :
+        slurm_format_opts = GLOBAL_SBILL_LONG_FORMAT
+        i += 1
+        continue
+
+
+    # *** SBILL Filter options ***
+    try:
+        i = parse_filter_opts(i,'--state','--state', has_argv=True, var=temp_opt) # Borrow
+    except IndexError :
+        print('Invalid input argument in -s, --state option :: List of states was NOT given.')
+        exit(1)
+    if len(temp_opt) > 1 :
+        state_selected = temp_opt[1].split(',')
+    elif len(temp_opt) == 1 :
+        if temp_opt[0].startswith('--state=') :
+            state_selected = temp_opt[0][8:].split(',')
+        else:
+            print('Invalid input argument in -s, --state option :: Ambiguous inputs, please explicitly use --state=<STATE_LIST>.')
+            exit(1)
+    if i != j : temp_opt = [] ; continue ;
+
+    if argv[i].startswith('--range='):
+        try:
+            temp = argv[i][8:].split('-')
+            if len(temp) == 1 :
+                range_minmax = [float(temp[0])]
+            elif len(temp) > 1 :
+                range_minmax = [float(temp[0]), float(temp[1])]
+            else:
+                print('Invalid format of --range option')
+                exit(1)
+        except ValueError :
+            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i][8:]+'\" to proper numbers, i.e., min and max')
+            exit(1)
+        i += 1
+        continue
+    if argv[i].startswith('--range'):
+        try:
+            temp = argv[i+1].split('-')
+            if len(temp) == 1 :
+                range_minmax = [float(temp[0])]
+            elif len(temp) > 1 :
+                range_minmax = [float(temp[0]), float(temp[1])]
+            else:
+                print('Invalid format of --range option')
+                exit(1)
+        except ValueError :
+            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i+1]+'\" to proper numbers, i.e., min and max')
+            exit(1)
+        i += 2
+        continue
+
+    if argv[i].startswith('--ncpus='):
+        try:
+            temp = argv[i][8:].split('-')
+            if len(temp) == 1 :
+                range_ncpu_minmax = [int(temp[0]), int(temp[0])]
+            elif len(temp) > 1 :
+                range_ncpu_minmax = [int(temp[0]), int(temp[1])]
+            else:
+                print('Invalid format of --ncpus option')
+                exit(1)
+        except ValueError :
+            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i][8:]+'\" to valid number(s)')
+            exit(1)
+        i += 1
+        continue
+    if argv[i].startswith('--ncpus'):
+        try:
+            temp = argv[i+1].split('-')
+            if len(temp) == 1 :
+                range_ncpu_minmax = [int(temp[0]), int(temp[0])]
+            elif len(temp) > 1 :
+                range_ncpu_minmax = [int(temp[0]), int(temp[1])]
+            else:
+                print('Invalid format of --ncpus option')
+                exit(1)
+        except ValueError :
+            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i+1]+'\" to valid number(s)')
+            exit(1)
+        i += 2
+        continue
+
+    if argv[i].startswith('--ngpus='):
+        try:
+            temp = argv[i][8:].split('-')
+            if len(temp) == 1 :
+                range_ngpu_minmax = [int(temp[0]), int(temp[0])]
+            elif len(temp) > 1 :
+                range_ngpu_minmax = [int(temp[0]), int(temp[1])]
+            else:
+                print('Invalid format of --ngpus option')
+                exit(1)
+        except ValueError :
+            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i][8:]+'\" to valid number(s)')
+            exit(1)
+        i += 1
+        continue
+    if argv[i].startswith('--ngpus'):
+        try:
+            temp = argv[i+1].split('-')
+            if len(temp) == 1 :
+                range_ngpu_minmax = [int(temp[0]), int(temp[0])]
+            elif len(temp) > 1 :
+                range_ngpu_minmax = [int(temp[0]), int(temp[1])]
+            else:
+                print('Invalid format of --ngpus option')
+                exit(1)
+        except ValueError :
+            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i+1]+'\" to valid number(s)')
+            exit(1)
+        i += 2
+        continue
+
+    # *** Slurm output options ***
+    if argv[i] == '--sumby' or argv[i] == '--sum-by' :
+        sum_by = argv[i+1]
+        if 'account' in sum_by.lower() :
+            sum_by = 'Account'
+        elif 'user' in sum_by.lower() :
+            sum_by = 'User'
+        else:
+            print('Unknown options/arguments :: \''+argv[i]+'\'\nSee \'sbill --help\'')
+            exit(1)
+        i += 2
+        continue
+    if argv[i].startswith('--sumby') :
+        sum_by = argv[i][7:]
+        if 'account' in sum_by.lower() :
+            sum_by = 'Account'
+        elif 'user' in sum_by.lower() :
+            sum_by = 'User'        
+        else:
+            print('Unknown options/arguments :: \''+argv[i]+'\'\nSee \'sbill --help\'')
+            exit(1)
+        i += 1
+        continue
+    if argv[i].startswith('--sum-by') :
+        sum_by = argv[i][8:]
+        if 'account' in sum_by.lower() :
+            sum_by = 'Account'
+        elif 'user' in sum_by.lower() :
+            sum_by = 'User'
+        else:
+            print('Unknown options/arguments :: \''+argv[i]+'\'\nSee \'sbill --help\'')
+            exit(1)
+        i += 1
+        continue
+
     try:
         i = parse_filter_opts(i,'-H','--histogram', has_argv=True, var=temp_opt) # Borrow
     except IndexError :
-        print('Invalid input argument in -H, --histogram option :: The number of bins was NOT given, try \"-H 10\".')
+        print('Invalid input argument in -H, --histogram option :: The number of bins was NOT given. Try \'-H 10\'')
         exit(1)
     if len(temp_opt) > 1 :
         is_show_job_histogram = True
@@ -334,7 +487,7 @@ while i < len(argv) :
         try:
             nbin_histogram = max(int(temp_opt[0]), 1)
         except ValueError :
-            print('Invalid input argument in -H, --histogram option :: cannot convert requested \"nbin\" to a proper numbers')
+            print('Invalid input argument in -H, --histogram option :: cannot convert \''+temp_opt[0]+'\' to a valid number')
             exit(1)
     elif len(temp_opt) == 1 :
         is_show_job_histogram = True
@@ -352,50 +505,44 @@ while i < len(argv) :
         try:
             nbin_histogram = max(int(temp_opt[0]), 1)
         except ValueError :
-            print('Invalid input argument in -H, --histogram option :: cannot convert requested \"nbin\" to a proper numbers')
+            print('Invalid input argument in -H, --histogram option :: cannot convert \''+temp_opt[0]+'\' to a valid number')
             exit(1)
     if i != j : temp_opt = [] ; continue ;
 
-    # Output option
-    if argv[i].startswith('--range='):
-        try:
-            temp = argv[i][8:].split('-')
-            if len(temp) == 1 :
-                range_minmax = [float(temp[0])]
-            elif len(temp) > 1 :
-                range_minmax = [float(temp[0]), float(temp[1])]
-            else:
-                print('Invalid format of --range option')
-                exit(1)
-        except ValueError :
-            print('Invalid input argument in', argv[i],':: cannot convert \"'+argv[i][8:]+'\" to proper numbers, i.e., min and max')
-            exit(1)
-        i += 1
-        continue
-
-    # Output option
-    if argv[i].startswith('--sumby') :
-        if argv[i][8:].lower() == 'account' :
-            sum_by = 'Account'
-        elif argv[i][8:].lower() == 'user' :
-            sum_by = 'User'
-        else:
-            print('Unregcognized input argument :: only \'--sumby=account\' or \'--sumby=user\' are valid.')
-            exit(1)
-        i += 1
-        continue
-
-    # File output option
     if argv[i].startswith('--to_csv=') :
         csv_outfile = argv[i][9:]
         if csv_outfile == '' :
-            print('Missing an input after :: --to_csv=')
+            print('Missing an input filename after :: --to_csv=<filename>')
             exit(1)
         else:
             i += 1
             continue
+    if argv[i].startswith('--to_csv') :
+        csv_outfile = argv[i+1]
+        if csv_outfile == '' :
+            print('Missing an input filename after :: --to_csv <filename>')
+            exit(1)
+        else:
+            i += 2
+            continue
 
-    # Other sacct options
+    if argv[i] == '-X' or argv[i] == '--summary' :
+        is_show_only_summary = True
+        print('sbill: note: --summary option implicitly implies --truncate (--trim-jobtime)')
+        slurm_filter_opts.append('--truncate')
+        i += 1
+        continue
+
+
+    # Other Slurm options
+    i = parse_filter_opts(i,'-T','--truncate', has_argv=False)
+    if i != j : continue ;
+
+    if argv[i] == '--trim' or argv[i] == '--trim-jobtime' :
+        slurm_filter_opts.append('--truncate')
+        i += 1
+        continue
+
     i = parse_filter_opts(i,'','--noconvert', has_argv=False, var=slurm_other_format_opts)
     if i != j : continue ;
 
@@ -406,16 +553,10 @@ while i < len(argv) :
         exit(1)
     if i != j : continue ;
 
-    # Summary report only
-    if argv[i] == '-X' or argv[i] == '--summary' :
-        is_show_only_summary = True
-        i += 1
-        continue
-
-    # Other options
+    # Other miscellaneous options
     if argv[i] == '-V' or argv[i] == '--version' :
         slurm = str(check_output(['sinfo','-V']).decode('ascii'))
-        print('sbill',__version__,'on',__HPC__,'utilizing', slurm, end='')
+        print('sbill',__version__,'on',__HPC__,'with', slurm, end='')
         exit(0)
     if argv[i] == '-h' or argv[i] == '--help' :
         show_sbill_usage()
@@ -425,15 +566,17 @@ while i < len(argv) :
         print("--- Fields available from SLURM ---")
         print(sacctformat)
         print("--- Additional fields available from SBILL ---")
-        print("= "+Service+", Billing, NGPUS, "+CPUusage+", "+GPUusage+", AllocMem\n")
+        print("= "+Service+", Billing, NGPUS, "+CPUusage+", "+GPUusage+", AllocRam\n")
         exit(0)
+
+    # Not intented to be used
     if argv[i].startswith('--other_sacct_opts="') :
         slurm_other_sacct_opts = argv[i][20:-1].split(' ')
         i += 1
         continue
 
     if i == j :
-        print('Unknown options/arguments ::', argv[i])
+        print('Unknown options/arguments :: \''+argv[i]+'\'\nSee \'sbill --help\'')
         exit(1)
 
 
@@ -584,8 +727,8 @@ slurm_opts = format_opts + slurm_filter_opts + slurm_other_sacct_opts
 usage = data_from_sacct(slurm_opts, columns=Treskey.copy(), sep=None, isAllocTres=True)
 
 # Get other essential fields
-format_opts = ['--format=jobid,account,state,elapsedraw','-X','-p','--noheader']
-col_names = ['JobID','Account','State','ElapsedRaw']
+format_opts = ['--format=jobid,account,ncpus,state,elapsedraw','-X','-p','--noheader']
+col_names = ['JobID','Account','NCPUS','State','ElapsedRaw']
 slurm_opts = format_opts + slurm_filter_opts + slurm_other_sacct_opts
 info = data_from_sacct(slurm_opts, columns=col_names, sep='|')
 
@@ -639,17 +782,30 @@ if len(state_selected) != 0 :
 
 # Compute Service and core-hour
 usage['ElapsedRaw'] = [ int(num) if num.isdigit() else 0 for num in usage['ElapsedRaw'] ]
+usage['NCPUS']  = [ int(num) for num in usage['NCPUS'] ]
 usage[Service]  = [ calService(b,s) for b,s in zip(usage[Treskey[0]],usage['ElapsedRaw']) ]
-usage[CPUusage] = [ calCPUusage(ncpu,s) for ncpu,s in zip(usage[Treskey[1]],usage['ElapsedRaw']) ]
-usage[GPUusage] = [ calGPUusage(ngpu,s) for ngpu,s in zip(usage[Treskey[2]], usage['ElapsedRaw']) ]
+usage[CPUusage] = [ calCPUusage(ncpu,s) for ncpu,s in zip(usage['NCPUS'],usage['ElapsedRaw']) ]
+usage[GPUusage] = [ calGPUusage(ngpu,s) for ngpu,s in zip(usage[Treskey[1]],usage['ElapsedRaw']) ]
 
-# Filter range before sum
+# Filter range before sum and get other info
 if len(range_minmax) >= 1 :
     if len(range_minmax) == 1 :
         mask = [ range_minmax[0]<=value for value in usage[Service] ]
     else:
-        mask = [ (range_minmax[0]<=value) & (value<=range_minmax[1]) for value in usage[Service] ]
+        mask = [ (range_minmax[0]<=value) & (value<range_minmax[1]) for value in usage[Service] ]
     pop_usage(mask)
+
+if len(range_ncpu_minmax) >= 2 :
+    mask = [ (range_ncpu_minmax[0]<=value) & (value<=range_ncpu_minmax[1]) for value in usage['NCPUS'] ]
+    pop_usage(mask)
+
+if len(range_ngpu_minmax) >= 2 :
+    if 'gpu' in Treskey[1] :
+        mask = [ (range_ngpu_minmax[0]<=value) & (value<=range_ngpu_minmax[1]) for value in usage[Treskey[1]] ]
+        pop_usage(mask)
+    else:
+        print('sbill: error: --ngpus is NOT supported for this cluster. Contact your system admin or remove it.')
+        exit(1)
 
 # If no jobs remain after being sorted out
 if len(usage['JobID']) == 0 :
@@ -684,10 +840,34 @@ for i in range(len(slurm_format_opts)) :
     if len(temp) > 1 and temp[1] != '' :
         len_opt[i] = int(temp[1])
         slurm_format_opts[i] = temp[0]
-
+        if temp[0].lower() == Service.lower():
+            ServiceDecimal = len_opt[i]
+        elif temp[0].lower() == CPUusage.lower():
+            CPUusageDecimal = len_opt[i]
+        elif temp[0].lower() == GPUusage.lower():
+            GPUusageDecimal = len_opt[i]
 
 # --- Headers of fields only appears in SBILL are fixed
 # --- Headers of fields from SACCT are as specified in --format=
+
+sacct_all_format_opts = ['AdminComment', 'AllocCPUS', 'AllocNodes', 'AllocTRES', 'AssocID',
+        'AveCPU', 'AveCPUFreq', 'AveDiskRead', 'AveDiskWrite', 'AvePages', 'AveRSS', 'AveVMSize', 
+        'BlockID', 'Cluster', 'Comment', 'Constraints', 'ConsumedEnergy', 'ConsumedEnergyRaw', 'Container', 'CPUTime', 'CPUTimeRAW',
+        'DBIndex', 'DerivedExitCode', 'Elapsed', 'Eligible', 'End', 'ExitCode', 'Flags', 'GID', 'Group',
+        'JobID', 'JobIDRaw', 'JobName', 'Layout', 'MaxDiskRead', 'MaxDiskReadNode', 'MaxDiskReadTask', 
+        'MaxDiskWrite', 'MaxDiskWriteNode', 'MaxDiskWriteTask', 'MaxPages', 'MaxPagesNode', 'MaxPagesTask', 
+        'MaxRSS', 'MaxRSSNode', 'MaxRSSTask', 'MaxVMSize', 'MaxVMSizeNode', 'MaxVMSizeTask', 'McsLabel', 'MinCPU', 'MinCPUNode', 'MinCPUTask',
+        'NNodes', 'NodeList', 'NTasks', 'Partition', 'Priority', 'QOS', 'QOSRAW', 'Reason', 
+        'ReqCPUFreq', 'ReqCPUFreqGov', 'ReqCPUFreqMax', 'ReqCPUFreqMin', 'ReqCPUS', 'ReqMem', 'ReqNodes', 'ReqTRES', 
+        'Reservation', 'ReservationId', 'Reserved', 'ResvCPU', 'ResvCPURAW', 
+        'Start', 'Submit', 'SubmitLine', 'Suspended', 'SystemComment', 'SystemCPU', 'Timelimit', 'TimelimitRaw', 'TotalCPU', 
+        'TRESUsageInAve', 'TRESUsageInMax', 'TRESUsageInMaxNode', 'TRESUsageInMaxTask', 
+        'TRESUsageInMin', 'TRESUsageInMinNode', 'TRESUsageInMinTask', 'TRESUsageInTot', 
+        'TRESUsageOutAve', 'TRESUsageOutMax', 'TRESUsageOutMaxNode', 'TRESUsageOutMaxTask', 
+        'TRESUsageOutMin', 'TRESUsageOutMinNode', 'TRESUsageOutMinTask', 'TRESUsageOutTot', 
+        'UID', 'User', 'UserCPU', 'WCKey', 'WCKeyID', 'WorkDir']
+         # 'Account', 'State', 'NCPUS', 'ElapsedRaw'
+lower_sacct_all_format_opts = [ n.lower() for n in sacct_all_format_opts ]
 
 sacct_format_opts = slurm_format_opts.copy()     # Fields to be inquired
 display_format_opts = slurm_format_opts.copy()   # Fields to be displayed
@@ -695,16 +875,13 @@ display_format_opts = slurm_format_opts.copy()   # Fields to be displayed
 lower_format_opts = [ n.lower() for n in slurm_format_opts ]
 j = 0
 for i in range(len(lower_format_opts)):
+    # Sbill required fields
     if 'billing' == lower_format_opts[i] :
         sacct_format_opts.pop(j)
         display_format_opts[i] = 'Billing'
     elif Service.lower() == lower_format_opts[i] :
         sacct_format_opts.pop(j)
         display_format_opts[i] = Service
-    elif 'ncpus' == lower_format_opts[i] :
-        sacct_format_opts[j] = 'NCPUS'
-        display_format_opts[i] = 'NCPUS'
-        j += 1
     elif 'ngpus' == lower_format_opts[i] :
         sacct_format_opts.pop(j)
         display_format_opts[i] = 'NGPUS'
@@ -714,16 +891,73 @@ for i in range(len(lower_format_opts)):
     elif GPUusage.lower() == lower_format_opts[i] :
         sacct_format_opts.pop(j)
         display_format_opts[i] = GPUusage
-    elif 'allocmem' == lower_format_opts[i] :
+    elif 'allocram' == lower_format_opts[i] :
         sacct_format_opts.pop(j)
-        display_format_opts[i] = 'AllocMem'
+        display_format_opts[i] = 'AllocRam'
     elif 'account' == lower_format_opts[i] :
         sacct_format_opts.pop(j)
         display_format_opts[i] = 'Account'
     elif 'state' == lower_format_opts[i] :
         sacct_format_opts.pop(j)
         display_format_opts[i] = 'State'
+    elif 'ncpus' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'NCPUS'
+    elif 'elapsedraw' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'ElapsedRaw'
+    
+    # (Possible) Misspelled/Hidden options
+    elif 'elapse' == lower_format_opts[i] :
+        sacct_format_opts[j]   = 'Elapsed'
+        display_format_opts[i] = 'Elapsed'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+        j += 1
+    elif 'elapseraw' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'ElapsedRaw'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+    elif 'node' == lower_format_opts[i] :
+        sacct_format_opts[j]   = 'NodeList'
+        display_format_opts[i] = 'NodeList'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+        j += 1
+    elif 'nnode' == lower_format_opts[i] :
+        sacct_format_opts[j]   = 'NNodes'
+        display_format_opts[i] = 'NNodes'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+        j += 1
+    elif 'ncpu' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'NCPUS'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+    elif 'cpus' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'NCPUS'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+    elif 'cpu' == lower_format_opts[i] :
+        sacct_format_opts[j]   = 'CPUTime'
+        display_format_opts[i] = 'CPUTime'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+        j += 1
+    elif 'ngpu' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'NGPUS'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+    elif 'gpus' == lower_format_opts[i] :
+        sacct_format_opts.pop(j)
+        display_format_opts[i] = 'NGPUS'
+        print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option. Change to \''+display_format_opts[i]+'\'.')
+
+    # SLURM fields
     else:
+        for k in range(len(lower_sacct_all_format_opts)):
+            if lower_sacct_all_format_opts[k] == lower_format_opts[i]:
+                sacct_format_opts[j]   = sacct_all_format_opts[k]
+                display_format_opts[i] = sacct_all_format_opts[k]
+                break
+        else:
+            print('sbill: warning: Undocumented field \''+slurm_format_opts[i]+'\' used in --format= option.')
         j += 1
 
 
@@ -742,8 +976,8 @@ info = data_from_sacct(slurm_opts, columns=sacct_format_opts, sep='|')
 
 # Merge to usage
 usage["Billing"]  = usage.pop(Treskey[0])
-usage["NGPUS"]    = usage.pop(Treskey[2])
-usage["AllocMem"] = usage.pop(Treskey[3])
+usage["NGPUS"]    = usage.pop(Treskey[1])
+usage["AllocRam"] = usage.pop(Treskey[2])
 
 jobid_list = info['JobID'].copy()
 last_index = len(usage['JobID']) -1
@@ -761,8 +995,9 @@ for k in list(info.keys()):
 if len(info['JobID']) == len(usage['JobID']) :
     usage.update(info)
 else:
-    print("If an error occurs here, please check the fields used in '--format=' option.")
-    #print("You encounter a bug in SBILL, please report this to somrathk@gmail.com")
+    print('sbill: error: Inconsistent job lists.')
+    print('\nPlease report this bug and your input command to your system admin and \"https://github.com/SKanoksi/SBILL-SLURM\"')
+    exit(1)
 
 
 # ---- Compute sum_by
@@ -780,6 +1015,21 @@ if len(sum_by) != 0 :
         sumby_results[t][Service] += usage[Service][i]
         sumby_results[t][CPUusage] += usage[CPUusage][i]
         sumby_results[t][GPUusage] += usage[GPUusage][i]
+
+
+# ----------- Save to ------------
+if csv_outfile != "" :
+    with open(csv_outfile, 'w') as f:
+        for k in display_format_opts :
+            f.write("%s," % k)
+        f.write("\n")
+        for n in range(len(usage[display_format_opts[0]])):
+            for k in display_format_opts :
+                f.write("%s," % str(usage[k][n]))
+            f.write("\n")
+    print('\n*** Job records are saved to \"'+csv_outfile+"\" ***\n")
+    print('---------- ---------- ----------')
+    is_show_only_summary = True
 
 
 # ------------ Print ------------
@@ -849,7 +1099,7 @@ if not is_show_only_summary :
 print('')
 if len(slurm_filter_opts) != 0 :
     print('With SLURM job filter options: ' + ' '.join(slurm_filter_opts))
-if len(state_selected) != 0 or len(range_minmax) >= 1 :
+if len(state_selected) != 0 or len(range_minmax) >= 1 or len(range_ncpu_minmax) >= 2 or len(range_ngpu_minmax) >= 2 :
     print('With SBILL job filter options:', end='')
     if len(state_selected) != 0 :
         print(' --state=' + ','.join(state_selected), end='')
@@ -857,6 +1107,16 @@ if len(state_selected) != 0 or len(range_minmax) >= 1 :
         print(' --range=' + str(range_minmax[0]), end='')
     elif len(range_minmax) > 1 :
         print(' --range=' + str(range_minmax[0]) + '-' + str(range_minmax[1]), end='')
+    if len(range_ncpu_minmax) >= 2 :
+        if range_ncpu_minmax[0] == range_ncpu_minmax[1] :
+            print(' --ncpus=' + str(range_ncpu_minmax[0]), end='')
+        else:
+            print(' --ncpus=' + str(range_ncpu_minmax[0]) + '-' + str(range_ncpu_minmax[1]), end='')
+    if len(range_ngpu_minmax) >= 2 :
+        if range_ngpu_minmax[0] == range_ngpu_minmax[1] :
+            print(' --ngpus=' + str(range_ngpu_minmax[0]), end='')
+        else:
+            print(' --ngpus=' + str(range_ngpu_minmax[0]) + '-' + str(range_ngpu_minmax[1]), end='')
     print('')
 print('')
 
@@ -935,28 +1195,80 @@ if is_show_job_histogram :
     from numpy import histogram as hist
     from math import ceil
 
-    if field_histogram == Service :
+    if field_histogram.lower() == Service.lower() :
+        field_histogram = Service
+        Decimal = ServiceDecimal + 1
+    elif field_histogram.lower() == CPUusage.lower() :
+        field_histogram = CPUusage
+        Decimal = CPUusageDecimal + 1
+    elif field_histogram.lower() == GPUusage.lower() :
+        field_histogram = GPUusage
+        Decimal = GPUusageDecimal + 1
+    elif field_histogram.lower() == 'nnode' or field_histogram.lower() == 'nodes' or field_histogram.lower() == 'nnodes' :
+        field_histogram = 'NNodes'
+        if not field_histogram in display_format_opts :
+            print('sbill: error: Histogram of nodes requires \'NNodes\' field in --format= option.')
+            exit(1)
+        Decimal = 1
+    elif field_histogram.lower() == 'ncpu' or field_histogram.lower() == 'cpus' or field_histogram.lower() == 'ncpus' :
+        field_histogram = 'NCPUS'
+        Decimal = 1
+    elif field_histogram.lower() == 'ngpu' or field_histogram.lower() == 'gpus' or field_histogram.lower() == 'ngpus' :
+        field_histogram = 'NGPUS'
+        Decimal = 1
+    elif field_histogram.lower() == 'runsec' :
+        display_field = 'RunSec'
+        field_histogram = 'ElapsedRaw'
+        Decimal = 1
+    elif field_histogram.lower() == 'runmin' :
+        display_field = 'RunMin'
+        field_histogram = 'ElapsedRaw'
+        Decimal = 1
+        usage[field_histogram] = [ float(value)/60.0 for value in usage[field_histogram] ]
+    elif field_histogram.lower() == 'runhour' :
+        display_field = 'RunHour'
+        field_histogram = 'ElapsedRaw'
+        Decimal = 1
+        usage[field_histogram] = [ float(value)/60.0/60.0 for value in usage[field_histogram] ]
+    else:
+        print('sbill: error: Unsupported histogram field \''+field_histogram+'\'\nSee \'sbill --help\'')
+        exit(1)
+
+    if field_histogram.lower() != 'elapsedraw' :
+        display_field = field_histogram
+
+    if field_histogram.lower() == Service.lower() :
         if len(range_minmax) >= 2 :
             hist_range = (range_minmax[0], range_minmax[1])
         elif len(range_minmax) == 1 :
-            hist_range = (range_minmax[0], max(usage[Service]))
+            hist_range = (range_minmax[0], max(usage[field_histogram]))
         else:
-            hist_range = (0.0, max(usage[Service]))
+            hist_range = (0.0, max(usage[field_histogram]))
+    elif field_histogram.lower() == 'ncpus' :
+        if len(range_ncpu_minmax) >= 2 :
+            hist_range = (range_ncpu_minmax[0], range_ncpu_minmax[1])
+        else:
+            hist_range = (0, max(usage[field_histogram]))
+    elif field_histogram.lower() == 'ngpus' :
+        if len(range_ngpu_minmax) >= 2 :
+            hist_range = (range_ngpu_minmax[0], range_ngpu_minmax[1])
+        else:
+            hist_range = (0, max(usage[field_histogram]))
     else:
-        usage[field_histogram] = [ int(x) for x in usage[field_histogram] ]
         hist_range = (0, max(usage[field_histogram]))
+
+    if field_histogram.lower() in ['nnodes', 'ncpus','ngpus','elapsedraw'] : # For fields of integer
+        int_spacing = int(hist_range[1] - hist_range[0]) + 1
+        if int_spacing < nbin_histogram :
+            nbin_histogram = int_spacing
+            print('sbill: warning: Specified number of bin is too fine for the data --> Readjusting.')
+
     count, bin_edges = hist(usage[field_histogram], bins=nbin_histogram, range=hist_range)
     
-    if field_histogram == Service :
-        Decimal = ServiceDecimal
-    elif field_histogram == CPUusage :
-        Decimal = CPUusageDecimal
-    elif field_histogram == GPUusage :
-        Decimal = GPUusageDecimal
-    else:
-        Decimal = 0 
     try_format = '{:,.'+str(Decimal)+'f}'
     num_char = max( [len(try_format.format(x)) for x in bin_edges] ) + 2
+    if num_char < 6 :
+        num_char = 6
     Format = '{:>'+str(num_char)+',.'+str(Decimal)+'f} - {:<'+str(num_char)+',.'+str(Decimal)+'f}'
     bin_names = [Format.format(x,y) for x,y in zip(bin_edges[:-1],bin_edges[1:])]
     count = list(count)
@@ -967,10 +1279,10 @@ if is_show_job_histogram :
     bar = ['x' * int(ceil(n/step)) if n!=0 else ' ' for n in count]
 
     Format = '{:^' + str(2*num_char+3) + '}'
-    print(Format.format(field_histogram+' range'), end='')
+    print(Format.format(display_field+' range'), end='')
     Format = '{:>' + str(len(str(max(count)))+2) + '}'
     print(Format.format('Count'), end='')
-    print('   '+label, end='')
+    print('  '+label, end='')
     print('')
 
     for j in range(nbin_histogram):
@@ -978,16 +1290,4 @@ if is_show_job_histogram :
         print(Format.format(count[j]), end='')
         print('   '+bar[j], end='')
         print('')
-
-
-# ----------- Save to ------------
-if csv_outfile != "" :
-    with open(csv_outfile, 'w') as f:
-        for k in display_format_opts :
-            f.write("%s," % k)
-        f.write("\n")
-        for n in range(len(usage[display_format_opts[0]])):
-            for k in display_format_opts :
-                f.write("%s," % str(usage[k][n]))
-            f.write("\n")
 


### PR DESCRIPTION
= Couple number format when displaying --histogram and what specified in --format = Remove hidden option -s (--state)
= Consistent header letters, e.g., when using --format=ncpus and --format=nCpUs --> NCPUS = Internally change --format=cpu,elapse to --format=cputime,elapsed for clarity and consistency = Warn and internally change --format=cpus,ncpu and others to --format=ncpus for consistency = Warn when undocumented SLURM field is used in --format = Make --range, --sumby, --to_csv accept arguments without '=' as well = --to_csv will make sbill display a message instead of job records = A bug in SACCT --ncpus option for GPU jobs?? --> separately implement --ncpus = Add --ngpus option as well
= Add 'nnode', 'ncpu', 'ngpu', 'runsec', 'runmin', 'runhour' fields for --histogram = --summary will implicitly imply --truncate
= Add --trim, --trim-jobtime alias of --truncate
= Add --sum-by-xxx, --sum-byxxx, --sumby-xxx, --sumbyxxx alias of --sumby=xxx = Add -l, --long option for quick --format=
= Rename AllocMem as AllocRam for clarity, since Mem could either imply RAM or VRAM (GPU memory)